### PR TITLE
Troubleshoot gcloud ssh connection failure

### DIFF
--- a/.github/workflows/deploy_to_vm.dev.yaml
+++ b/.github/workflows/deploy_to_vm.dev.yaml
@@ -44,28 +44,32 @@ jobs:
 
     - name: Ensure IAP firewall rule exists
       run: |
-        # Check if IAP firewall rule exists
+        NETWORK="${{ vars.GCP_VPC_NETWORK }}"
+        NETWORK=${NETWORK:-default}
         if ! gcloud compute firewall-rules describe iap-allow-ssh --project=${{ vars.GCP_PROJECT_ID }} 2>/dev/null; then
-          echo "Creating IAP firewall rule..."
+          echo "Creating IAP firewall rule on network ${NETWORK}..."
           gcloud compute firewall-rules create iap-allow-ssh \
+            --network="${NETWORK}" \
             --allow tcp:22 \
             --source-ranges 35.235.240.0/20 \
-            --description "Allow SSH from anywhere" \
+            --description "Allow SSH from IAP" \
             --direction INGRESS \
             --project=${{ vars.GCP_PROJECT_ID }} \
-            --priority 1000
+            --priority 1000 \
             --target-tags allow-iap-ssh
         else
-          echo "Default SSH firewall rule already exists"
+          echo "IAP SSH firewall rule already exists"
         fi
 
 
     - name: Ensure general SSH firewall rule exists
       run: |
-        # Check if default SSH firewall rule exists
+        NETWORK="${{ vars.GCP_VPC_NETWORK }}"
+        NETWORK=${NETWORK:-default}
         if ! gcloud compute firewall-rules describe default-allow-ssh --project=${{ vars.GCP_PROJECT_ID }} 2>/dev/null; then
-          echo "Creating default SSH firewall rule..."
+          echo "Creating default SSH firewall rule on network ${NETWORK}..."
           gcloud compute firewall-rules create default-allow-ssh \
+            --network="${NETWORK}" \
             --allow tcp:22 \
             --source-ranges 0.0.0.0/0 \
             --description "Allow SSH from anywhere" \
@@ -75,6 +79,14 @@ jobs:
         else
           echo "Default SSH firewall rule already exists"
         fi
+
+    - name: Tag VM to match firewall rule
+      run: |
+        gcloud compute instances add-tags ${{ vars.GCP_VM_NAME }} \
+          --zone=us-central1-a \
+          --project=${{ vars.GCP_PROJECT_ID }} \
+          --tags=allow-iap-ssh \
+          --quiet
 
     - name: Wait for 10 seconds
       run: |


### PR DESCRIPTION
Fix IAP SSH connectivity by dynamically resolving the VPC network for firewall rules and ensuring the VM is tagged to match the IAP firewall rule.

The previous setup resulted in `4003 failed to connect to backend` errors because IAP traffic couldn't reach port 22. This was due to firewall rules not being created on the correct VPC network and the VM lacking the `allow-iap-ssh` tag required by the IAP firewall rule.

---
<a href="https://cursor.com/background-agent?bcId=bc-274877f4-f397-4b36-abfc-8c6830a95d9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-274877f4-f397-4b36-abfc-8c6830a95d9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

