### PR TITLE
Fix unhealthy fansboda-web service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ EXPOSE 8080
 
 # Health check (updated for port 8080)
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/ || exit 1
+    CMD curl -f http://127.0.0.1:8080/login || exit 1
 
 # Run the application using virtual environment
 CMD [".venv/bin/gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "120", "app:app"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,91 @@
+services:
+  # Flask application
+  web:
+    image: oloft/fansboda-dev:latest
+    container_name: fansboda-web
+    restart: unless-stopped
+    environment:
+      - FLASK_ENV=development
+    volumes:
+      - ./static:/app/static:ro # Mount static files for nginx
+    networks:
+      - fansboda-network
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/login" ]
+      interval: 300s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Nginx reverse proxy
+  nginx:
+    image: nginx:alpine
+    container_name: fansboda-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80" # HTTP - redirects to HTTPS
+      - "443:443" # HTTPS - main application
+    volumes:
+    - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    - ./static:/var/www/static:ro
+    - ./certificates:/etc/nginx/ssl:ro # Mount SSL certificates
+    - ./certbot-webroot:/var/www/certbot:ro # Mount certbot webroot for ACME challenge
+    depends_on:
+      web:
+        condition: service_healthy
+    networks:
+      - fansboda-network
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost/" ]
+      interval: 300s
+      timeout: 10s
+      retries: 3
+  
+   # Nginx for ACME challenge only (runs temporarily)
+  nginx-acme:
+    image: nginx:alpine
+    container_name: fansboda-nginx-acme
+    restart: "no"  # Only run when needed
+    ports:
+      - "80:80"  # Use different port to avoid conflict
+    volumes:
+      - ./nginx-acme.conf:/etc/nginx/nginx.conf:ro
+      - ./certbot-webroot:/var/www/certbot:ro
+    networks:
+      - fansboda-network
+    profiles:
+      - acme  # Only start with --profile acme
+  
+    # Certbot for initial certificate
+  certbot:
+    image: certbot/certbot:latest
+    container_name: fansboda-certbot
+    restart: "no"  # Run once
+    volumes:
+      - ./certificates:/etc/letsencrypt:rw
+      - ./certbot-webroot:/var/www/certbot:rw
+    command: certonly --webroot --webroot-path=/var/www/certbot --email olof.thornell@gmail.com --agree-tos --no-eff-email -d dev.fansboda.dpdns.org
+    depends_on:
+      - nginx-acme
+    networks:
+      - fansboda-network
+    profiles:
+      - acme  # Only start with --profile acme
+
+  # Certbot renewal service
+  certbot-renew:
+    image: certbot/certbot:latest
+    container_name: fansboda-certbot-renew
+    restart: unless-stopped
+    volumes:
+      - ./certificates:/etc/letsencrypt:rw
+      - ./certbot-webroot:/var/www/certbot:rw
+    command: sh -c "trap exit TERM; while :; do certbot renew --webroot --webroot-path=/var/www/certbot; sleep 12h & wait $${!}; done;"
+    depends_on:
+      - nginx
+    networks:
+      - fansboda-network
+
+networks:
+  fansboda-network:
+    driver: bridge


### PR DESCRIPTION
Update `fansboda-web` healthcheck to use `127.0.0.1` and target `/login` to resolve unhealthiness.

The previous healthcheck `curl -f http://localhost:8080/` was failing because the root path `/` redirects (302 Found), and `localhost` could resolve to IPv6 while Gunicorn was listening on IPv4. The updated healthcheck uses `127.0.0.1` to force IPv4 and targets the `/login` endpoint, which returns a direct 200 OK response.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e7bb823-d33d-4a5c-93aa-57da5b67b7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e7bb823-d33d-4a5c-93aa-57da5b67b7d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update healthcheck to curl 127.0.0.1:8080/login and add a dev docker-compose with nginx reverse proxy and certbot services.
> 
> - **Dockerfile**:
>   - Update `HEALTHCHECK` to `curl -f http://127.0.0.1:8080/login` (from `/` on `localhost`).
> - **Dev environment (`docker-compose.dev.yml`)**:
>   - Add `web` service using `olof/fansboda-dev:latest` with healthcheck on `http://127.0.0.1:8080/login` and mounted `static`.
>   - Add `nginx` reverse proxy exposing `80`/`443`, mounting `nginx.conf`, `static`, SSL certificates, and certbot webroot; waits for healthy `web`.
>   - Add `nginx-acme` (profile `acme`) for ACME challenges.
>   - Add `certbot` one-time issuance (profile `acme`) and `certbot-renew` periodic renewal service.
>   - Define `fansboda-network` bridge network.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1472ec1cb82e7531cce97e2c0e825fd497502b8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->