### PR TITLE
Fix unhealthy fansboda-web service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ EXPOSE 8080
 
 # Health check (updated for port 8080)
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/ || exit 1
+    CMD curl -f http://localhost:8080/health || exit 1
 
 # Run the application using virtual environment
 CMD [".venv/bin/gunicorn", "--bind", "0.0.0.0:8080", "--workers", "4", "--timeout", "120", "app:app"]

--- a/config.py
+++ b/config.py
@@ -25,6 +25,9 @@ def get_database_uri(env_name="dev"):
         if not neon_database_url:
             neon_database_url = _get_secret_from_gcp("DATABASE_URL")
             if not neon_database_url:
+                neon_database_url = _get_secret_from_gcp("DATABASE_URL_DEV")
+
+            if not neon_database_url:
                 raise ValueError(
                     "DATABASE_URL environment variable must be set for development. "
                     "Get your connection string from https://neon.tech"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - fansboda-network
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
       interval: 300s
       timeout: 10s
       retries: 3

--- a/src/routes/home.py
+++ b/src/routes/home.py
@@ -7,6 +7,11 @@ from src.route_protection import dev_only
 home_bp = Blueprint("home", __name__)
 
 
+@home_bp.route("/health")
+def health():
+    return "OK", 200
+
+
 @home_bp.route("/")
 @home_bp.route("/index")
 @allowed_user_required


### PR DESCRIPTION
Fix `fansboda-web` service unhealthy status by implementing a dedicated health check endpoint and ensuring correct database URL retrieval in development.

The `fansboda-web` service was marked as unhealthy due to two primary issues:
1.  The previous health check endpoint (`/`) redirected to `/login`, which is not suitable for a robust health check. A new `/health` endpoint now provides a clear 200 OK status.
2.  In the development environment, the application failed to start because `config.py` was not correctly fetching the `DATABASE_URL_DEV` secret, leading to a missing database connection string.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d3964d0-dbcf-4cb0-9a27-d4df9f228b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d3964d0-dbcf-4cb0-9a27-d4df9f228b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

